### PR TITLE
feat: add getters for window position, fix: proceed without cursor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ target/
 vcpkg/
 *.profraw
 *.profdata
+.idea

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,0 @@
-[toolchain]
-channel = "nightly"

--- a/src/renderer/sdl.rs
+++ b/src/renderer/sdl.rs
@@ -46,7 +46,7 @@ pub(crate) struct Renderer {
     controllers: HashMap<ControllerId, GameController>,
     title: String,
     settings: RendererSettings,
-    cursor: Cursor,
+    cursor: Option<Cursor>,
     blend_mode: SdlBlendMode,
     current_font: FontId,
     font_size: u16,
@@ -150,8 +150,14 @@ impl Rendering for Renderer {
 
         let title = s.title.clone();
         let primary_window = WindowCanvas::new(&context, &mut s)?;
-        let cursor = Cursor::from_system(SystemCursor::Arrow).map_err(Error::Renderer)?;
-        cursor.set();
+        let cursor_result = Cursor::from_system(SystemCursor::Arrow).map_err(Error::Renderer);
+        let cursor = match cursor_result {
+            Ok(c) => Some(c),
+            Err(_) => None,
+        };
+        if cursor.is_some(){
+            cursor.as_ref().unwrap().set();
+        }
         let window_target = primary_window.id;
         let mut windows = HashMap::new();
         windows.insert(primary_window.id, primary_window);

--- a/src/renderer/sdl.rs
+++ b/src/renderer/sdl.rs
@@ -155,8 +155,8 @@ impl Rendering for Renderer {
             Ok(c) => Some(c),
             Err(_) => None,
         };
-        if cursor.is_some(){
-            cursor.as_ref().unwrap().set();
+        if let Ok(cursor) = Cursor::from_system(SystemCursor::Arrow) {
+            cursor.set();
         }
         let window_target = primary_window.id;
         let mut windows = HashMap::new();

--- a/src/renderer/sdl/window.rs
+++ b/src/renderer/sdl/window.rs
@@ -254,7 +254,9 @@ impl WindowRenderer for Renderer {
                         Some(SdlCursor::from_surface(surface, *x, *y).map_err(Error::Renderer)?)
                     }
                 };
-                self.cursor.as_ref().unwrap().set();
+                if self.cursor.is_some(){
+                    self.cursor.as_ref().unwrap().set();
+                }
                 if !self.context.mouse().is_cursor_showing() {
                     self.context.mouse().show_cursor(true);
                 }

--- a/src/renderer/sdl/window.rs
+++ b/src/renderer/sdl/window.rs
@@ -247,14 +247,14 @@ impl WindowRenderer for Renderer {
             Some(cursor) => {
                 self.cursor = match cursor {
                     Cursor::System(cursor) => {
-                        SdlCursor::from_system((*cursor).into()).map_err(Error::Renderer)?
+                        Some(SdlCursor::from_system((*cursor).into()).map_err(Error::Renderer)?)
                     }
                     Cursor::Image(path, (x, y)) => {
                         let surface = Surface::from_file(path).map_err(Error::Renderer)?;
-                        SdlCursor::from_surface(surface, *x, *y).map_err(Error::Renderer)?
+                        Some(SdlCursor::from_surface(surface, *x, *y).map_err(Error::Renderer)?)
                     }
                 };
-                self.cursor.set();
+                self.cursor.as_ref().unwrap().set();
                 if !self.context.mouse().is_cursor_showing() {
                     self.context.mouse().show_cursor(true);
                 }

--- a/src/renderer/sdl/window.rs
+++ b/src/renderer/sdl/window.rs
@@ -254,8 +254,8 @@ impl WindowRenderer for Renderer {
                         Some(SdlCursor::from_surface(surface, *x, *y).map_err(Error::Renderer)?)
                     }
                 };
-                if self.cursor.is_some(){
-                    self.cursor.as_ref().unwrap().set();
+                if let Some(cursor) = &self.cursor {
+                    cursor.set();
                 }
                 if !self.context.mouse().is_cursor_showing() {
                     self.context.mouse().show_cursor(true);

--- a/src/renderer/sdl/window.rs
+++ b/src/renderer/sdl/window.rs
@@ -324,6 +324,12 @@ impl WindowRenderer for Renderer {
         Ok(self.window()?.size())
     }
 
+    /// Position of the current window target as `(x, y)`.
+    #[inline]
+    fn window_position(&self) -> Result<(i32, i32)> {
+        Ok(self.window()?.position())
+    }
+
     /// Set dimensions of the current window target as `(width, height)`.
     #[inline]
     fn set_window_dimensions(&mut self, (width, height): (u32, u32)) -> Result<()> {

--- a/src/window.rs
+++ b/src/window.rs
@@ -553,6 +553,28 @@ impl PixState {
         self.renderer.set_window_dimensions((width, height))
     }
 
+    /// The x of the current window.
+    ///
+    /// # Errors
+    ///
+    /// If the window has been closed or is invalid, then an error is returned.
+    #[inline]
+    pub fn window_x(&self) -> PixResult<i32> {
+        let (x, _) = self.window_position()?;
+        Ok(x)
+    }
+
+    /// The y of the current window.
+    ///
+    /// # Errors
+    ///
+    /// If the window has been closed or is invalid, then an error is returned.
+    #[inline]
+    pub fn window_y(&self) -> PixResult<i32> {
+        let (_, y) = self.window_position()?;
+        Ok(y)
+    }
+
     /// The center [Point] of the current render target.
     ///
     /// # Errors

--- a/src/window.rs
+++ b/src/window.rs
@@ -553,28 +553,6 @@ impl PixState {
         self.renderer.set_window_dimensions((width, height))
     }
 
-    /// The x of the current window.
-    ///
-    /// # Errors
-    ///
-    /// If the window has been closed or is invalid, then an error is returned.
-    #[inline]
-    pub fn window_position_x(&self) -> PixResult<i32> {
-        let (x, _) = self.window_position()?;
-        Ok(x)
-    }
-
-    /// The y of the current window.
-    ///
-    /// # Errors
-    ///
-    /// If the window has been closed or is invalid, then an error is returned.
-    #[inline]
-    pub fn window_position_y(&self) -> PixResult<i32> {
-        let (_, y) = self.window_position()?;
-        Ok(y)
-    }
-
     /// The center [Point] of the current render target.
     ///
     /// # Errors

--- a/src/window.rs
+++ b/src/window.rs
@@ -212,6 +212,9 @@ pub(crate) trait WindowRenderer {
     /// Dimensions of the current window target as `(width, height)`.
     fn window_dimensions(&self) -> PixResult<(u32, u32)>;
 
+    /// Position of the current window target as `(x, y)`.
+    fn window_position(&self) -> PixResult<(i32, i32)>;
+
     /// Set dimensions of the current window target as `(width, height)`.
     fn set_window_dimensions(&mut self, dimensions: (u32, u32)) -> PixResult<()>;
 
@@ -441,6 +444,16 @@ impl PixState {
         self.renderer.set_window_dimensions(dimensions)
     }
 
+    /// The position of the current window target as `(x, y)`.
+    ///
+    /// # Errors
+    ///
+    /// If the window has been closed or is invalid, then an error is returned.
+    #[inline]
+    pub fn window_position(&self) -> PixResult<(i32, i32)> {
+        self.renderer.window_position()
+    }
+
     /// Returns the rendering viewport of the current render target.
     ///
     /// # Errors
@@ -538,6 +551,28 @@ impl PixState {
     pub fn set_window_height(&mut self, height: u32) -> PixResult<()> {
         let (width, _) = self.window_dimensions()?;
         self.renderer.set_window_dimensions((width, height))
+    }
+
+    /// The x of the current window.
+    ///
+    /// # Errors
+    ///
+    /// If the window has been closed or is invalid, then an error is returned.
+    #[inline]
+    pub fn window_position_x(&self) -> PixResult<i32> {
+        let (x, _) = self.window_position()?;
+        Ok(x)
+    }
+
+    /// The y of the current window.
+    ///
+    /// # Errors
+    ///
+    /// If the window has been closed or is invalid, then an error is returned.
+    #[inline]
+    pub fn window_position_y(&self) -> PixResult<i32> {
+        let (_, y) = self.window_position()?;
+        Ok(y)
     }
 
     /// The center [Point] of the current render target.


### PR DESCRIPTION
I needed to save the window's position and size in a settings file, so I can restore them on the next start. (I also want to save window flags, but that's next). Also I tried to cross-compile my app for a MIPS device (a handheld console - PocketGo2). It failed to start because there's no cursor support. So I made cursor optional. There are probably inaccuracies in the implementation. I hope you can quickly see them when you review this PR.