### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1](https://github.com/lukexor/pix-engine/compare/0.8.0..0.8.1) - 2026-04-25
+
+### 🐛 Bug Fixes
+
+
+- Fixed color byte order pending updated rust-sdl2 release - ([8827bac](https://github.com/lukexor/pix-engine/commit/8827bacef75741a40bae1e7db16226b4fd1a3f87))
+- Fixed unused warning - ([e88f9da](https://github.com/lukexor/pix-engine/commit/e88f9da3cb09cbedce999a440cfa5f80648ee29a))
+- Fix removing joypad devices - ([539eb18](https://github.com/lukexor/pix-engine/commit/539eb18d93437c86ab3ec13ca052335277d00902))
+
+### 📚 Documentation
+
+
+- Fixed docs - ([284b8dc](https://github.com/lukexor/pix-engine/commit/284b8dcdd27e5c25b778ee39f46ca149f1b60670))
+
+### 🎨 Styling
+
+
+- Fixed lints - ([839145c](https://github.com/lukexor/pix-engine/commit/839145ca6253a2950782da6d30c52445bd233a1b))
+- Fix lints - ([e361694](https://github.com/lukexor/pix-engine/commit/e36169475bdb41926c4e5a8b2d1ed73da4424cd3))
+
+### 🧪 Testing
+
+
+- Updated tests - ([ebe6f47](https://github.com/lukexor/pix-engine/commit/ebe6f471c43395ad7bc5f32b13860f7ce0238b6f))
+
+### ⚙️ Miscellaneous Tasks
+
+- *(ci)* Fixed changelog - ([ea653e5](https://github.com/lukexor/pix-engine/commit/ea653e5c2bd1adc25c7d30d4ad226d3579c0b42b))
+
+- Fix homebrew paths - ([4baff7c](https://github.com/lukexor/pix-engine/commit/4baff7c89d9fc005b931bbe6aa7bd170ec0cd002))
+- Update actions - ([44520b2](https://github.com/lukexor/pix-engine/commit/44520b2e2b3b963df848c4d99718df88aa465a16))
+- Reduce dependabot - ([b901fc6](https://github.com/lukexor/pix-engine/commit/b901fc66c16db3034be6428b2c113e9c1f01afe6))
+- Updated deps - ([4a9c949](https://github.com/lukexor/pix-engine/commit/4a9c949ebb64cb8c44ee78f2a35ff146b734d1ae))
+- Updated lints and set msrv - ([45fb86a](https://github.com/lukexor/pix-engine/commit/45fb86ad06daa7f79ba9a28c4896147f03455c70))
+- Updated deps - ([12e684e](https://github.com/lukexor/pix-engine/commit/12e684ec06e161416f6bf47b015102a4aba27f56))
+- Updated deps - ([780baf7](https://github.com/lukexor/pix-engine/commit/780baf71f2754f7ef9bf7718195150a61ea06434))
+- Update dependencies - ([1128b2d](https://github.com/lukexor/pix-engine/commit/1128b2dc132cf064ce22a969927662b9f49222d8))
+- Updated deps - ([d3e647e](https://github.com/lukexor/pix-engine/commit/d3e647e4167a884b385635837fbee3841ca11357))
+- Updated deps - ([f9cd068](https://github.com/lukexor/pix-engine/commit/f9cd06868007d8c64c82363aae9cae7990f87874))
+- Updated deps - ([2a6515e](https://github.com/lukexor/pix-engine/commit/2a6515e91166bec6e36987dec28ba86080697ce8))
+- Updated deps - ([a6c49ba](https://github.com/lukexor/pix-engine/commit/a6c49ba538ff2a9caac82154368341e4dd7ca802))
+- Updated packages - ([dba3424](https://github.com/lukexor/pix-engine/commit/dba34240dabf667c15970e2cb04dd7bc840ec885))
+- Updated cargo deps - ([bccdb27](https://github.com/lukexor/pix-engine/commit/bccdb27720d2de9765c271709a2a7e0975fd6cd4))
+
+
 ## [0.8.0] - 2023-10-30
 
 ### ⛰️  Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,33 +25,15 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
-dependencies = [
- "backtrace",
-]
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "backtrace"
-version = "0.3.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-link",
-]
 
 [[package]]
 name = "bitflags"
@@ -70,18 +43,18 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "c_vec"
@@ -151,9 +124,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -216,9 +189,9 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -229,12 +202,6 @@ dependencies = [
  "wasip3",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.32.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
@@ -255,6 +222,12 @@ dependencies = [
  "equivalent",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "heck"
@@ -282,12 +255,12 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -305,15 +278,15 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -333,9 +306,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.182"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "log"
@@ -345,9 +318,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
 ]
@@ -370,9 +343,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -393,26 +366,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.37.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "pix-engine"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "getrandom",
  "log",
  "lru",
@@ -434,7 +398,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -478,24 +442,24 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom",
@@ -504,15 +468,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -553,15 +517,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "rustversion"
@@ -595,9 +553,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -644,15 +602,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "syn"
-version = "2.0.115"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e614ed320ac28113fa64972c4262d5dbc89deacdfd00c34a3e4cea073243c12"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -711,9 +669,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-xid"
@@ -729,11 +687,11 @@ checksum = "579a42fc0b8e0c63b76519a339be31bed574929511fa53c1a3acae26eb258f29"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -742,14 +700,14 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -760,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -770,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -783,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -818,7 +776,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -856,6 +814,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -906,7 +870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "pix-engine"
 repository = "https://github.com/lukexor/pix-engine.git"
 resolver = "2"
 rust-version = "1.70.0"
-version = "0.8.0"
+version = "0.8.1"
 exclude = ["/images", "/audio", "/pkg"]
 build = "build.rs"
 


### PR DESCRIPTION



## 🤖 New release

* `pix-engine`: 0.8.0 -> 0.8.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/lukexor/pix-engine/compare/0.8.0..0.8.1) - 2026-08-21

### 🐛 Bug Fixes


- Correct caching, counter and lifecycle bugs - ([955c386](https://github.com/lukexor/pix-engine/commit/955c38648a658b71ec4d3291f2fd2debe3e928aa))
- Fixed color byte order pending updated rust-sdl2 release - ([8827bac](https://github.com/lukexor/pix-engine/commit/8827bacef75741a40bae1e7db16226b4fd1a3f87))
- Fixed unused warning - ([e88f9da](https://github.com/lukexor/pix-engine/commit/e88f9da3cb09cbedce999a440cfa5f80648ee29a))
- Fix removing joypad devices - ([539eb18](https://github.com/lukexor/pix-engine/commit/539eb18d93437c86ab3ec13ca052335277d00902))

### 📚 Documentation


- Add CLAUDE.md for Claude Code - ([7de235c](https://github.com/lukexor/pix-engine/commit/7de235cf4a7b004b4063d65a45f54f0b68453ed2))
- Fixed docs - ([284b8dc](https://github.com/lukexor/pix-engine/commit/284b8dcdd27e5c25b778ee39f46ca149f1b60670))

### 🎨 Styling


- Fixed lints - ([839145c](https://github.com/lukexor/pix-engine/commit/839145ca6253a2950782da6d30c52445bd233a1b))
- Fix lints - ([e361694](https://github.com/lukexor/pix-engine/commit/e36169475bdb41926c4e5a8b2d1ed73da4424cd3))

### 🧪 Testing


- Updated tests - ([ebe6f47](https://github.com/lukexor/pix-engine/commit/ebe6f471c43395ad7bc5f32b13860f7ce0238b6f))

### ⚙️ Miscellaneous Tasks

- *(ci)* Fixed changelog - ([ea653e5](https://github.com/lukexor/pix-engine/commit/ea653e5c2bd1adc25c7d30d4ad226d3579c0b42b))

- Fix homebrew paths - ([4baff7c](https://github.com/lukexor/pix-engine/commit/4baff7c89d9fc005b931bbe6aa7bd170ec0cd002))
- Update actions - ([44520b2](https://github.com/lukexor/pix-engine/commit/44520b2e2b3b963df848c4d99718df88aa465a16))
- Reduce dependabot - ([b901fc6](https://github.com/lukexor/pix-engine/commit/b901fc66c16db3034be6428b2c113e9c1f01afe6))
- Updated deps - ([4a9c949](https://github.com/lukexor/pix-engine/commit/4a9c949ebb64cb8c44ee78f2a35ff146b734d1ae))
- Updated lints and set msrv - ([45fb86a](https://github.com/lukexor/pix-engine/commit/45fb86ad06daa7f79ba9a28c4896147f03455c70))
- Updated deps - ([12e684e](https://github.com/lukexor/pix-engine/commit/12e684ec06e161416f6bf47b015102a4aba27f56))
- Updated deps - ([780baf7](https://github.com/lukexor/pix-engine/commit/780baf71f2754f7ef9bf7718195150a61ea06434))
- Update dependencies - ([1128b2d](https://github.com/lukexor/pix-engine/commit/1128b2dc132cf064ce22a969927662b9f49222d8))
- Updated deps - ([d3e647e](https://github.com/lukexor/pix-engine/commit/d3e647e4167a884b385635837fbee3841ca11357))
- Updated deps - ([f9cd068](https://github.com/lukexor/pix-engine/commit/f9cd06868007d8c64c82363aae9cae7990f87874))
- Updated deps - ([2a6515e](https://github.com/lukexor/pix-engine/commit/2a6515e91166bec6e36987dec28ba86080697ce8))
- Updated deps - ([a6c49ba](https://github.com/lukexor/pix-engine/commit/a6c49ba538ff2a9caac82154368341e4dd7ca802))
- Updated packages - ([dba3424](https://github.com/lukexor/pix-engine/commit/dba34240dabf667c15970e2cb04dd7bc840ec885))
- Updated cargo deps - ([bccdb27](https://github.com/lukexor/pix-engine/commit/bccdb27720d2de9765c271709a2a7e0975fd6cd4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).